### PR TITLE
Add GR-Lite tutorial, ZooClaw eval, and multimodal evaluator

### DIFF
--- a/datasets/__init__.py
+++ b/datasets/__init__.py
@@ -12,6 +12,12 @@ from .registry import (
     get_dataset,
     list_available_datasets
 )
+from .zooclaw_dataset import (
+    ZooClawImageDataset,
+    ZooClawTextDataset,
+    load_zooclaw_task,
+    load_zooclaw_dataset,
+)
 
 __all__ = [
     'BaseDataset',
@@ -20,6 +26,10 @@ __all__ = [
     'registry',
     'register_dataset',
     'get_dataset',
-    'list_available_datasets'
+    'list_available_datasets',
+    'ZooClawImageDataset',
+    'ZooClawTextDataset',
+    'load_zooclaw_task',
+    'load_zooclaw_dataset',
 ]
 

--- a/datasets/zooclaw_dataset.py
+++ b/datasets/zooclaw_dataset.py
@@ -1,0 +1,201 @@
+"""
+ZooClaw-Fashion dataset loader for LookBench.
+
+Loads BEIR-style JSON datasets (queries.json, corpus.json, ground_truth.json)
+with support for multi-modal retrieval tasks (text2image, image2text, text2text).
+"""
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import torch
+from PIL import Image
+from torch.utils.data import Dataset
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class ZooClawImageDataset(Dataset):
+    """Dataset that yields (PIL.Image, item_id) pairs."""
+
+    def __init__(self, items: List[dict], image_key: str, id_key: str,
+                 transform=None, data_root: str = ""):
+        self.items = items
+        self.image_key = image_key
+        self.id_key = id_key
+        self.transform = transform
+        self.data_root = data_root
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, idx) -> Tuple[torch.Tensor, int]:
+        item = self.items[idx]
+        image_path = item[self.image_key]
+        if not os.path.isabs(image_path):
+            image_path = os.path.join(self.data_root, image_path)
+        img = Image.open(image_path).convert("RGB")
+        if self.transform is not None:
+            img = self.transform(img)
+        return img, item[self.id_key]
+
+
+class ZooClawTextDataset(Dataset):
+    """Dataset that yields (text_string, item_id) pairs."""
+
+    def __init__(self, items: List[dict], text_key: str, id_key: str):
+        self.items = items
+        self.text_key = text_key
+        self.id_key = id_key
+
+    def __len__(self):
+        return len(self.items)
+
+    def __getitem__(self, idx) -> Tuple[str, int]:
+        item = self.items[idx]
+        return item[self.text_key], item[self.id_key]
+
+
+def load_zooclaw_task(
+    task_dir: str,
+    task_type: str,
+    transform=None,
+    data_root: str = "",
+    use_long_queries: bool = False,
+) -> Dict:
+    """
+    Load a single ZooClaw-Fashion retrieval task.
+
+    Args:
+        task_dir: Path to task directory (e.g., "data/zooclaw-fashion/text2image")
+        task_type: One of "text2image", "image2text", "text2text"
+        transform: Image transform (required for tasks involving images)
+        data_root: Root directory for resolving relative image paths
+        use_long_queries: If True and available, use queries_long.json for text queries
+
+    Returns:
+        Dict with keys: "query_dataset", "corpus_dataset", "ground_truth",
+                        "query_modality", "corpus_modality"
+    """
+    task_dir = Path(task_dir)
+
+    # Load ground truth
+    gt_path = task_dir / "ground_truth.json"
+    with open(gt_path) as f:
+        ground_truth = json.load(f)
+    # Ensure keys are strings mapping to list of ints
+    ground_truth = {str(k): [int(x) for x in v] for k, v in ground_truth.items()}
+
+    if task_type == "text2image":
+        # Query = text, Corpus = images
+        if use_long_queries and (task_dir / "queries_long.json").exists():
+            queries_file = "queries_long.json"
+            text_key = "long_query_llm"
+        else:
+            queries_file = "queries.json"
+            text_key = "short_query"
+
+        with open(task_dir / queries_file) as f:
+            queries = json.load(f)
+        with open(task_dir / "corpus.json") as f:
+            corpus = json.load(f)
+
+        query_dataset = ZooClawTextDataset(queries, text_key=text_key, id_key="query_id")
+        corpus_dataset = ZooClawImageDataset(
+            corpus, image_key="image_path", id_key="corpus_id",
+            transform=transform, data_root=data_root,
+        )
+        return {
+            "query_dataset": query_dataset,
+            "corpus_dataset": corpus_dataset,
+            "ground_truth": ground_truth,
+            "query_modality": "text",
+            "corpus_modality": "image",
+        }
+
+    elif task_type == "image2text":
+        # Query = images, Corpus = text
+        with open(task_dir / "queries.json") as f:
+            queries = json.load(f)
+        with open(task_dir / "corpus.json") as f:
+            corpus = json.load(f)
+
+        query_dataset = ZooClawImageDataset(
+            queries, image_key="image_path", id_key="query_id",
+            transform=transform, data_root=data_root,
+        )
+        corpus_dataset = ZooClawTextDataset(corpus, text_key="short_text", id_key="corpus_id")
+        return {
+            "query_dataset": query_dataset,
+            "corpus_dataset": corpus_dataset,
+            "ground_truth": ground_truth,
+            "query_modality": "image",
+            "corpus_modality": "text",
+        }
+
+    elif task_type == "text2text":
+        # Query = text, Corpus = text
+        with open(task_dir / "queries.json") as f:
+            queries = json.load(f)
+        with open(task_dir / "corpus.json") as f:
+            corpus = json.load(f)
+
+        query_dataset = ZooClawTextDataset(queries, text_key="short_query", id_key="query_id")
+        corpus_dataset = ZooClawTextDataset(corpus, text_key="short_text", id_key="corpus_id")
+        return {
+            "query_dataset": query_dataset,
+            "corpus_dataset": corpus_dataset,
+            "ground_truth": ground_truth,
+            "query_modality": "text",
+            "corpus_modality": "text",
+        }
+
+    else:
+        raise ValueError(f"Unknown task type: {task_type}. Expected: text2image, image2text, text2text")
+
+
+def load_zooclaw_dataset(
+    dataset_dir: str,
+    tasks: Optional[List[str]] = None,
+    transform=None,
+    data_root: Optional[str] = None,
+    use_long_queries: bool = False,
+) -> Dict[str, Dict]:
+    """
+    Load all tasks from a ZooClaw-Fashion dataset directory.
+
+    Args:
+        dataset_dir: Root dataset directory containing task subdirectories
+        tasks: List of tasks to load (default: all available)
+        transform: Image transform
+        data_root: Root for image paths (defaults to dataset_dir)
+        use_long_queries: Use long queries where available
+
+    Returns:
+        Dict mapping task_name -> task_data (from load_zooclaw_task)
+    """
+    dataset_dir = Path(dataset_dir)
+    if data_root is None:
+        data_root = str(dataset_dir)
+
+    all_tasks = ["text2image", "image2text", "text2text"]
+    if tasks is None:
+        tasks = [t for t in all_tasks if (dataset_dir / t).exists()]
+
+    result = {}
+    for task in tasks:
+        task_dir = dataset_dir / task
+        if not task_dir.exists():
+            logger.warning(f"Task directory not found: {task_dir}, skipping")
+            continue
+        logger.info(f"Loading task: {task}")
+        result[task] = load_zooclaw_task(
+            str(task_dir), task, transform=transform,
+            data_root=data_root, use_long_queries=use_long_queries,
+        )
+
+    return result

--- a/examples/04_zooclaw_eval.py
+++ b/examples/04_zooclaw_eval.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""
+ZooClaw-Fashion Evaluation Example for LookBench.
+
+Evaluates a model on the ZooClaw-Fashion benchmark (text2image retrieval).
+
+Usage:
+    # From look-bench root directory
+    python examples/04_zooclaw_eval.py \
+        --dataset-dir /path/to/zooclaw-fashion \
+        --model-name google/siglip2-base-patch16-384 \
+        --batch-size 128
+
+    # With long queries
+    python examples/04_zooclaw_eval.py \
+        --dataset-dir /path/to/zooclaw-fashion \
+        --model-name google/siglip2-base-patch16-384 \
+        --long-queries
+
+    # With HuggingFace dataset
+    python examples/04_zooclaw_eval.py \
+        --hf-dataset srpone/zooclaw-fashion \
+        --model-name google/siglip2-base-patch16-384
+"""
+
+import argparse
+import importlib.util
+import json
+import sys
+import os
+
+_root = os.path.join(os.path.dirname(__file__), "..")
+sys.path.insert(0, _root)
+
+import torch
+from transformers import AutoModel
+
+
+def _load_module(name, filepath):
+    """Load a module directly from file to avoid package __init__ circular imports."""
+    spec = importlib.util.spec_from_file_location(name, filepath)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_zooclaw_ds = _load_module("zooclaw_dataset", os.path.join(_root, "datasets", "zooclaw_dataset.py"))
+load_zooclaw_dataset = _zooclaw_ds.load_zooclaw_dataset
+
+_mm_eval = _load_module("multimodal_evaluator", os.path.join(_root, "runner", "multimodal_evaluator.py"))
+evaluate_zooclaw_task = _mm_eval.evaluate_zooclaw_task
+
+
+def load_processor(model_name: str):
+    """Load model processor, with fallback for SigLIP2 tokenizer compatibility."""
+    from transformers import AutoProcessor
+    try:
+        return AutoProcessor.from_pretrained(model_name, trust_remote_code=True)
+    except Exception:
+        # Older transformers may fail on SigLIP2 (GemmaTokenizer).
+        # Build a composite processor from image_processor + tokenizer.
+        from transformers import AutoImageProcessor, AutoTokenizer
+        image_processor = AutoImageProcessor.from_pretrained(model_name, trust_remote_code=True)
+        try:
+            tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+        except Exception:
+            from transformers import GemmaTokenizer
+            tokenizer = GemmaTokenizer.from_pretrained(model_name, trust_remote_code=True)
+
+        class _CompositeProcessor:
+            def __init__(self, img_proc, tok):
+                self.image_processor = img_proc
+                self.tokenizer = tok
+
+            def __call__(self, text=None, images=None, **kwargs):
+                result = {}
+                if images is not None:
+                    result.update(self.image_processor(images=images, return_tensors=kwargs.get("return_tensors")))
+                if text is not None:
+                    result.update(self.tokenizer(
+                        text,
+                        return_tensors=kwargs.get("return_tensors"),
+                        padding=kwargs.get("padding", False),
+                        truncation=kwargs.get("truncation", False),
+                        max_length=kwargs.get("max_length"),
+                    ))
+                return result
+
+        return _CompositeProcessor(image_processor, tokenizer)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="ZooClaw-Fashion evaluation")
+    parser.add_argument("--dataset-dir", type=str, default=None,
+                        help="Path to ZooClaw-Fashion dataset directory")
+    parser.add_argument("--hf-dataset", type=str, default=None,
+                        help="HuggingFace dataset ID (e.g., srpone/zooclaw-fashion)")
+    parser.add_argument("--model-name", type=str,
+                        default="google/siglip2-base-patch16-384")
+    parser.add_argument("--tasks", nargs="+",
+                        default=["text2image"],
+                        choices=["text2image", "image2text", "text2text"])
+    parser.add_argument("--long-queries", action="store_true",
+                        help="Use long-form queries for text2image")
+    parser.add_argument("--batch-size", type=int, default=128)
+    parser.add_argument("--num-workers", type=int, default=4)
+    parser.add_argument("--max-length", type=int, default=64)
+    parser.add_argument("--top-k", nargs="+", type=int, default=[1, 5, 10, 20])
+    parser.add_argument("--output", type=str, default=None,
+                        help="Save results to JSON file")
+    args = parser.parse_args()
+
+    # Resolve dataset directory
+    if args.hf_dataset:
+        from huggingface_hub import snapshot_download
+        args.dataset_dir = snapshot_download(
+            repo_id=args.hf_dataset, repo_type="dataset",
+        )
+        print(f"Downloaded dataset to: {args.dataset_dir}")
+
+    if not args.dataset_dir:
+        parser.error("Either --dataset-dir or --hf-dataset is required")
+
+    # Load model + processor
+    print(f"Loading model: {args.model_name}")
+    model = AutoModel.from_pretrained(args.model_name, trust_remote_code=True)
+    processor = load_processor(args.model_name)
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model.to(device).eval()
+
+    # Load dataset (no transform needed — processor handles preprocessing)
+    print(f"Loading ZooClaw-Fashion dataset from: {args.dataset_dir}")
+    task_data = load_zooclaw_dataset(
+        args.dataset_dir,
+        tasks=args.tasks,
+        transform=None,  # raw PIL images — processor handles it
+        use_long_queries=args.long_queries,
+    )
+
+    # Evaluate each task
+    all_results = {}
+    for task_name, data in task_data.items():
+        print(f"\n{'='*60}")
+        print(f"Evaluating: {task_name}")
+        print(f"  Queries: {len(data['query_dataset'])} ({data['query_modality']})")
+        print(f"  Corpus:  {len(data['corpus_dataset'])} ({data['corpus_modality']})")
+        print(f"{'='*60}")
+
+        results = evaluate_zooclaw_task(
+            model=model,
+            task_data=data,
+            processor=processor,
+            batch_size=args.batch_size,
+            num_workers=args.num_workers,
+            top_k=args.top_k,
+            max_length=args.max_length,
+        )
+        all_results[task_name] = results
+
+        print(f"\nResults for {task_name}:")
+        for k, v in results.items():
+            print(f"  {k}: {v:.4f}")
+
+    # Summary
+    print(f"\n{'='*60}")
+    print("Summary")
+    print(f"{'='*60}")
+    for task_name, results in all_results.items():
+        print(f"\n{task_name}:")
+        for k, v in results.items():
+            print(f"  {k}: {v:.4f}")
+
+    # Save results
+    if args.output:
+        with open(args.output, "w") as f:
+            json.dump(all_results, f, indent=2)
+        print(f"\nResults saved to: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/notebooks/04_gr_lite_tutorial.ipynb
+++ b/notebooks/04_gr_lite_tutorial.ipynb
@@ -1,0 +1,127 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "2ft40np7jsm",
+   "source": "# GR-Lite: Fashion Image Retrieval Tutorial\n\nThis notebook demonstrates how to load and use the [GR-Lite](https://huggingface.co/srpone/gr-lite) model for fashion image retrieval.\n\nGR-Lite is a ViT-L/16 model (303M params) fine-tuned from DINOv3 for fashion retrieval. It produces 1024-dim L2-normalized image embeddings.\n\n**What you'll learn:**\n1. Load GR-Lite from HuggingFace Hub\n2. Extract image embeddings\n3. Compute similarity between images\n4. Run image retrieval on LookBench",
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "id": "rr8wdkxgjcr",
+   "source": "## 1. Installation",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "28r06aq1qbv",
+   "source": "!pip install -q transformers torch torchvision pillow",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "l3dcvf6fo4",
+   "source": "## 2. Load the Model\n\nGR-Lite is hosted on HuggingFace and can be loaded with `AutoModel`. The `trust_remote_code=True` flag is required because the model uses a custom architecture.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "d51h12lr3n",
+   "source": "from transformers import AutoModel\nimport torch\n\nmodel = AutoModel.from_pretrained(\"srpone/gr-lite\", trust_remote_code=True)\nmodel.eval()\n\ndevice = \"cuda\" if torch.cuda.is_available() else \"cpu\"\nmodel = model.to(device)\n\nprint(f\"Model loaded on {device}\")\nprint(f\"Parameters: {sum(p.numel() for p in model.parameters()) / 1e6:.1f}M\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "co71oye232o",
+   "source": "## 3. Preprocessing\n\nGR-Lite expects 336x336 RGB images normalized with ImageNet statistics.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "4g5b7jr6exx",
+   "source": "from torchvision import transforms\n\ntransform = transforms.Compose([\n    transforms.Resize((336, 336)),\n    transforms.ToTensor(),\n    transforms.Normalize(mean=[0.485, 0.456, 0.406], std=[0.229, 0.224, 0.225]),\n])",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "kjuurq4qd",
+   "source": "## 4. Extract Embeddings\n\nThe model returns `pooler_output` (L2-normalized CLS embedding) and `last_hidden_state` (full patch sequence).",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "83p3t49gc7",
+   "source": "from PIL import Image\nimport requests\nfrom io import BytesIO\n\n# Load a sample image (replace with your own image path)\nurl = \"https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/transformers/model_doc/vit_architecture.jpg\"\ntry:\n    response = requests.get(url, timeout=5)\n    image = Image.open(BytesIO(response.content)).convert(\"RGB\")\nexcept Exception:\n    # Fallback: create a dummy image for demonstration\n    image = Image.new(\"RGB\", (400, 400), color=(128, 128, 128))\n\n# Preprocess and extract embedding\npixel_values = transform(image).unsqueeze(0).to(device)  # [1, 3, 336, 336]\n\nwith torch.no_grad():\n    output = model(pixel_values)\n\nembedding = output.pooler_output  # [1, 1024]\nprint(f\"Embedding shape: {embedding.shape}\")\nprint(f\"L2 norm: {embedding.norm().item():.4f}\")\nprint(f\"First 5 values: {embedding[0, :5].tolist()}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8jqzhioqm03",
+   "source": "## 5. Image Similarity\n\nSince embeddings are L2-normalized, cosine similarity is just a dot product.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "2l9505nm5",
+   "source": "# Create a second image (slightly modified) for comparison\nimage2 = image.rotate(15)\n\npixel_values2 = transform(image2).unsqueeze(0).to(device)\n\nwith torch.no_grad():\n    output2 = model(pixel_values2)\n\nemb1 = output.pooler_output   # from the original image\nemb2 = output2.pooler_output  # from the rotated image\n\n# Cosine similarity (dot product since embeddings are L2-normalized)\nsimilarity = (emb1 @ emb2.T).item()\nprint(f\"Cosine similarity (original vs rotated): {similarity:.4f}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2qy7gfeo5u2",
+   "source": "## 6. Batch Feature Extraction\n\nFor retrieval workloads, use a DataLoader for efficient batch processing.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "voo7wckr82",
+   "source": "from torch.utils.data import DataLoader, Dataset\n\nclass ImageListDataset(Dataset):\n    \"\"\"Simple dataset wrapping a list of PIL images.\"\"\"\n    def __init__(self, images, transform):\n        self.images = images\n        self.transform = transform\n\n    def __len__(self):\n        return len(self.images)\n\n    def __getitem__(self, idx):\n        return self.transform(self.images[idx])\n\n# Create some dummy images for demonstration\ndummy_images = [Image.new(\"RGB\", (400, 400), color=(r, g, b))\n                for r, g, b in [(255, 0, 0), (0, 255, 0), (0, 0, 255), (128, 128, 0)]]\n\ndataset = ImageListDataset(dummy_images, transform)\nloader = DataLoader(dataset, batch_size=2, shuffle=False)\n\nall_embeddings = []\nwith torch.no_grad():\n    for batch in loader:\n        out = model(batch.to(device))\n        all_embeddings.append(out.pooler_output.cpu())\n\nembeddings = torch.cat(all_embeddings, dim=0)  # [4, 1024]\nprint(f\"Batch embeddings shape: {embeddings.shape}\")\n\n# Pairwise similarity matrix\nsim_matrix = embeddings @ embeddings.T\nprint(f\"\\nPairwise similarity matrix:\\n{sim_matrix.numpy().round(3)}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2fq087domb7",
+   "source": "## 7. Image Retrieval Example\n\nGiven a query image, find the most similar images from a gallery by ranking cosine similarities.",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "id": "yeb78ifyhf",
+   "source": "def retrieve(query_emb, gallery_embs, top_k=5):\n    \"\"\"Retrieve top-K most similar gallery items for a query.\"\"\"\n    # query_emb: [1, D], gallery_embs: [N, D]\n    scores = (query_emb @ gallery_embs.T).squeeze(0)  # [N]\n    top_k_indices = scores.argsort(descending=True)[:top_k]\n    return top_k_indices, scores[top_k_indices]\n\n# Use first image as query, rest as gallery\nquery_emb = embeddings[0:1]      # [1, 1024]\ngallery_embs = embeddings[1:]    # [3, 1024]\n\nindices, scores = retrieve(query_emb, gallery_embs, top_k=3)\n\nprint(\"Query: Image 0 (red)\")\nprint(\"\\nRetrieval results:\")\ncolors = [\"green\", \"blue\", \"yellow\"]\nfor rank, (idx, score) in enumerate(zip(indices, scores)):\n    print(f\"  Rank {rank+1}: Image {idx.item()+1} ({colors[idx]}) — similarity: {score.item():.4f}\")",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": []
+  },
+  {
+   "cell_type": "markdown",
+   "id": "wltngt8t47q",
+   "source": "## Resources\n\n- [GR-Lite on HuggingFace](https://huggingface.co/srpone/gr-lite)\n- [LookBench Paper](https://arxiv.org/abs/2601.14706)\n- [LookBench Dataset](https://huggingface.co/datasets/srpone/look-bench)\n- [LookBench GitHub](https://github.com/SerendipityOneInc/look-bench)",
+   "metadata": {}
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "torch>=2.0.0",
     "torchvision>=0.15.0",
-    "transformers>=4.30.0",
+    "transformers>=4.49.0",
     "datasets>=2.14.0",
     "numpy>=1.24.0",
     "pandas>=2.0.0",
@@ -61,7 +61,6 @@ Repository = "https://github.com/SerendipityOneInc/look-bench"
 "Bug Tracker" = "https://github.com/SerendipityOneInc/look-bench/issues"
 
 [tool.setuptools]
-# Auto-discover packages
 packages = {find = {}}
 
 [tool.setuptools.package-data]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Core Dependencies
 torch>=2.0.0
 torchvision>=0.15.0
-transformers>=4.30.0
+transformers>=4.49.0  # SigLIP2 support requires >=4.49
 datasets>=2.14.0
 numpy>=1.24.0
 pandas>=2.0.0
@@ -19,4 +19,3 @@ tqdm>=4.65.0
 # black>=23.3.0
 # flake8>=6.0.0
 # mypy>=1.3.0
-

--- a/runner/multimodal_evaluator.py
+++ b/runner/multimodal_evaluator.py
@@ -1,0 +1,244 @@
+"""
+Multi-modal evaluator for LookBench.
+
+Supports text-to-image retrieval with explicit ground truth mappings
+(ZooClaw-Fashion format).
+
+Follows the same encoding approach as fine-tune-vit (InferenceEngine):
+- Images: processor(images=..., return_tensors="pt") → model.get_image_features(**inputs)
+- Text:   processor(text=..., return_tensors="pt", padding=True, truncation=True) → model.get_text_features(**inputs)
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import DataLoader
+from tqdm import tqdm
+
+logger = logging.getLogger(__name__)
+
+
+def extract_image_features(
+    model, dataset, processor, batch_size: int = 128, num_workers: int = 4,
+) -> tuple:
+    """Extract image features using processor + model.get_image_features.
+
+    Args:
+        model: The VLE model (e.g. SiglipModel, CLIPModel)
+        dataset: Dataset yielding (PIL.Image, item_id) pairs
+        processor: The model's processor (AutoProcessor or compatible)
+        batch_size: Batch size
+        num_workers: DataLoader workers
+
+    Returns:
+        (features [N, D], ids [N])
+    """
+    from PIL import Image
+
+    def _collate(batch):
+        images, ids = zip(*batch)
+        return list(images), list(ids)
+
+    loader = DataLoader(
+        dataset, batch_size=batch_size, num_workers=num_workers,
+        shuffle=False, drop_last=False, collate_fn=_collate,
+    )
+    all_features = []
+    all_ids = []
+
+    model.eval()
+    device = next(model.parameters()).device
+
+    with torch.no_grad():
+        for images, ids in tqdm(loader, desc="Encoding images"):
+            inputs = processor(images=images, return_tensors="pt")
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            features = model.get_image_features(**inputs)
+            if not isinstance(features, torch.Tensor):
+                features = features.pooler_output
+            features = F.normalize(features.float(), p=2, dim=1)
+            all_features.append(features.cpu())
+            all_ids.extend(ids if isinstance(ids, list) else ids.tolist())
+
+    return torch.cat(all_features, dim=0), all_ids
+
+
+def extract_text_features(
+    model, dataset, processor, batch_size: int = 128, max_length: int = 64,
+) -> tuple:
+    """Extract text features using processor + model.get_text_features.
+
+    Args:
+        model: The VLE model
+        dataset: Dataset yielding (text_string, item_id) pairs
+        processor: The model's processor
+        batch_size: Batch size
+        max_length: Max token length
+
+    Returns:
+        (features [N, D], ids [N])
+    """
+    def _collate(batch):
+        texts, ids = zip(*batch)
+        return list(texts), list(ids)
+
+    loader = DataLoader(
+        dataset, batch_size=batch_size, shuffle=False,
+        drop_last=False, collate_fn=_collate,
+    )
+    all_features = []
+    all_ids = []
+
+    model.eval()
+    device = next(model.parameters()).device
+
+    with torch.no_grad():
+        for texts, ids in tqdm(loader, desc="Encoding text"):
+            inputs = processor(
+                text=texts, return_tensors="pt",
+                padding="max_length", truncation=True, max_length=max_length,
+            )
+            inputs = {k: v.to(device) for k, v in inputs.items()}
+            features = model.get_text_features(**inputs)
+            if not isinstance(features, torch.Tensor):
+                features = features.pooler_output
+            features = F.normalize(features.float(), p=2, dim=1)
+            all_features.append(features.cpu())
+            all_ids.extend(ids)
+
+    return torch.cat(all_features, dim=0), all_ids
+
+
+def evaluate_retrieval(
+    query_features: torch.Tensor,
+    query_ids: List[int],
+    corpus_features: torch.Tensor,
+    corpus_ids: List[int],
+    ground_truth: Dict[str, List[int]],
+    top_k: List[int] = None,
+) -> Dict[str, float]:
+    """Evaluate retrieval with explicit ground truth mapping.
+
+    Args:
+        query_features: [N_query, D]
+        query_ids: List of query IDs
+        corpus_features: [N_corpus, D]
+        corpus_ids: List of corpus IDs
+        ground_truth: {query_id_str: [corpus_id, ...]}
+        top_k: List of K values for Recall@K
+
+    Returns:
+        Dict with recall@K and MRR values
+    """
+    if top_k is None:
+        top_k = [1, 5, 10, 20]
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    query_features = F.normalize(query_features.to(device), p=2, dim=1)
+    corpus_features = F.normalize(corpus_features.to(device), p=2, dim=1)
+
+    # Compute similarity matrix
+    logger.info("Computing similarity matrix...")
+    similarity = torch.mm(query_features, corpus_features.t())  # [N_q, N_c]
+
+    # Evaluate
+    recall_scores = {k: [] for k in top_k}
+    mrr_scores = []
+
+    max_k = max(top_k)
+
+    for i, qid in enumerate(tqdm(query_ids, desc="Evaluating")):
+        gt_cids = set(ground_truth.get(str(qid), []))
+        if not gt_cids:
+            continue
+
+        # Get top-K corpus indices
+        _, topk_indices = torch.topk(similarity[i], min(max_k, len(corpus_ids)))
+        topk_indices = topk_indices.cpu().tolist()
+
+        # Map indices back to corpus IDs
+        topk_cids = [corpus_ids[idx] for idx in topk_indices]
+
+        # Recall@K
+        for k in top_k:
+            hit = any(cid in gt_cids for cid in topk_cids[:k])
+            recall_scores[k].append(1.0 if hit else 0.0)
+
+        # MRR
+        rr = 0.0
+        for rank, cid in enumerate(topk_cids, start=1):
+            if cid in gt_cids:
+                rr = 1.0 / rank
+                break
+        mrr_scores.append(rr)
+
+    results = {}
+    for k in top_k:
+        if recall_scores[k]:
+            results[f"recall@{k}"] = round(np.mean(recall_scores[k]), 4)
+    if mrr_scores:
+        results["mrr"] = round(np.mean(mrr_scores), 4)
+
+    for key, val in results.items():
+        logger.info(f"  {key}: {val:.4f}")
+
+    return results
+
+
+def evaluate_zooclaw_task(
+    model,
+    task_data: Dict,
+    processor,
+    batch_size: int = 128,
+    num_workers: int = 4,
+    top_k: List[int] = None,
+    max_length: int = 64,
+) -> Dict[str, float]:
+    """Run evaluation for a single ZooClaw task.
+
+    Args:
+        model: The VLE model (SiglipModel, CLIPModel, etc.)
+        task_data: Output from load_zooclaw_task()
+        processor: Model processor (AutoProcessor or compatible)
+        batch_size: Batch size for feature extraction
+        num_workers: DataLoader workers
+        top_k: K values for Recall@K
+        max_length: Max token length for text encoding
+
+    Returns:
+        Dict with recall@K and MRR values
+    """
+    query_modality = task_data["query_modality"]
+    corpus_modality = task_data["corpus_modality"]
+
+    # Extract query features
+    if query_modality == "image":
+        q_features, q_ids = extract_image_features(
+            model, task_data["query_dataset"], processor,
+            batch_size=batch_size, num_workers=num_workers,
+        )
+    else:
+        q_features, q_ids = extract_text_features(
+            model, task_data["query_dataset"], processor,
+            batch_size=batch_size, max_length=max_length,
+        )
+
+    # Extract corpus features
+    if corpus_modality == "image":
+        c_features, c_ids = extract_image_features(
+            model, task_data["corpus_dataset"], processor,
+            batch_size=batch_size, num_workers=num_workers,
+        )
+    else:
+        c_features, c_ids = extract_text_features(
+            model, task_data["corpus_dataset"], processor,
+            batch_size=batch_size, max_length=max_length,
+        )
+
+    return evaluate_retrieval(
+        q_features, q_ids, c_features, c_ids,
+        task_data["ground_truth"], top_k=top_k,
+    )


### PR DESCRIPTION
## Summary
- Add `notebooks/04_gr_lite_tutorial.ipynb`: end-to-end tutorial for loading GR-Lite from HuggingFace Hub via `AutoModel.from_pretrained`, extracting embeddings, and running image retrieval
- Add `datasets/zooclaw_dataset.py` + `examples/04_zooclaw_eval.py`: ZooClaw-Fashion benchmark evaluation support
- Add `runner/multimodal_evaluator.py`: text-to-image retrieval evaluator (Recall@K, MRR)
- Bump `transformers>=4.49.0` for SigLIP2 support
- Update `pyproject.toml` with `transformers>=4.49.0`

## Test plan
- [ ] Verify notebook runs end-to-end on Colab / local
- [ ] Verify ZooClaw eval produces correct results with `04_zooclaw_eval.py`
- [ ] Verify `multimodal_evaluator.py` matches fine-tune-vit baseline numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)